### PR TITLE
Add English language support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,46 +8,46 @@
 </head>
 <body>
   <header>
-    <div class="logo">בינה לקהילה ומסורת</div>
+    <div class="logo" id="logo">בינה לקהילה ומסורת</div>
     <nav>
       <select id="langSwitcher">
         <option value="he" selected>עברית</option>
         <option value="en">English</option>
       </select>
       <button>🔍</button>
-      <button>התחברות</button>
-      <button class="primary">הרשמה</button>
+      <button id="btnLogin">התחברות</button>
+      <button id="btnSignup" class="primary">הרשמה</button>
     </nav>
   </header>
 
   <main>
     <section class="search-box">
-      <h2>מחפשים בית כנסת קרוב?</h2>
-      <p>הכנס את המיקום שלך או שם קהילה:</p>
-      <input type="text" placeholder="הכנס את המיקום שלך או שם קהילה">
+      <h2 id="searchTitle">מחפשים בית כנסת קרוב?</h2>
+      <p id="searchDesc">הכנס את המיקום שלך או שם קהילה:</p>
+      <input id="searchInput" type="text" placeholder="הכנס את המיקום שלך או שם קהילה">
       <button>🔍</button>
     </section>
 
     <section class="apps">
-      <h3>רוצה להישאר מחובר?</h3>
-      <p>הורד את האפליקציה שלנו לסלולרי:</p>
+      <h3 id="appsTitle">רוצה להישאר מחובר?</h3>
+      <p id="appsDesc">הורד את האפליקציה שלנו לסלולרי:</p>
       <button>Google Play</button>
       <button>App Store</button>
     </section>
 
     <section class="features">
-      <h3>מה אפשר לעשות עם המערכת?</h3>
+      <h3 id="featuresTitle">מה אפשר לעשות עם המערכת?</h3>
       <ul>
-        <li>לקבל זמני תפילה ופעילויות בקהילה</li>
-        <li>להירשם, לתרום, להודיע הודעות</li>
-        <li>לנהל עליות, ספרי תורה, חברים בקהילה</li>
+        <li><span id="feature1">לקבל זמני תפילה ופעילויות בקהילה</span></li>
+        <li><span id="feature2">להירשם, לתרום, להודיע הודעות</span></li>
+        <li><span id="feature3">לנהל עליות, ספרי תורה, חברים בקהילה</span></li>
       </ul>
     </section>
 
     <section class="cta">
-      <h3>חדש כאן?</h3>
-      <button>רוצה להצטרף לקהילה</button>
-      <button class="primary">מנהל קהילה – פתח קהילה</button>
+      <h3 id="ctaTitle">חדש כאן?</h3>
+      <button id="btnJoin">רוצה להצטרף לקהילה</button>
+      <button id="btnCreate" class="primary">מנהל קהילה – פתח קהילה</button>
     </section>
   </main>
   <script src="scripts.js"></script>

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -1,11 +1,72 @@
+const translations = {
+  en: {
+    title: "Kolekta - Wisdom for Community and Tradition",
+    logo: "Wisdom for Community & Tradition",
+    login: "Login",
+    signup: "Sign Up",
+    searchTitle: "Looking for a nearby synagogue?",
+    searchDesc: "Enter your location or community name:",
+    searchPlaceholder: "Enter your location or community name",
+    appsTitle: "Want to stay connected?",
+    appsDesc: "Download our mobile app:",
+    featuresTitle: "What can you do with the system?",
+    feature1: "Get prayer times and community activities",
+    feature2: "Register, donate, send announcements",
+    feature3: "Manage aliyot, Torah scrolls, community members",
+    ctaTitle: "New here?",
+    join: "Want to join a community",
+    create: "Community admin – open a community",
+  },
+  he: {
+    title: "קולקטה - בינה לקהילה ומסורת",
+    logo: "בינה לקהילה ומסורת",
+    login: "התחברות",
+    signup: "הרשמה",
+    searchTitle: "מחפשים בית כנסת קרוב?",
+    searchDesc: "הכנס את המיקום שלך או שם קהילה:",
+    searchPlaceholder: "הכנס את המיקום שלך או שם קהילה",
+    appsTitle: "רוצה להישאר מחובר?",
+    appsDesc: "הורד את האפליקציה שלנו לסלולרי:",
+    featuresTitle: "מה אפשר לעשות עם המערכת?",
+    feature1: "לקבל זמני תפילה ופעילויות בקהילה",
+    feature2: "להירשם, לתרום, להודיע הודעות",
+    feature3: "לנהל עליות, ספרי תורה, חברים בקהילה",
+    ctaTitle: "חדש כאן?",
+    join: "רוצה להצטרף לקהילה",
+    create: "מנהל קהילה – פתח קהילה",
+  },
+};
+
+function applyTranslations(lang) {
+  const t = translations[lang];
+  if (!t) return;
+  document.title = t.title;
+  document.getElementById("logo").innerText = t.logo;
+  document.getElementById("btnLogin").innerText = t.login;
+  document.getElementById("btnSignup").innerText = t.signup;
+  document.getElementById("searchTitle").innerText = t.searchTitle;
+  document.getElementById("searchDesc").innerText = t.searchDesc;
+  document.getElementById("searchInput").placeholder = t.searchPlaceholder;
+  document.getElementById("appsTitle").innerText = t.appsTitle;
+  document.getElementById("appsDesc").innerText = t.appsDesc;
+  document.getElementById("featuresTitle").innerText = t.featuresTitle;
+  document.getElementById("feature1").innerText = t.feature1;
+  document.getElementById("feature2").innerText = t.feature2;
+  document.getElementById("feature3").innerText = t.feature3;
+  document.getElementById("ctaTitle").innerText = t.ctaTitle;
+  document.getElementById("btnJoin").innerText = t.join;
+  document.getElementById("btnCreate").innerText = t.create;
+}
+
+function setLanguage(lang) {
+  document.documentElement.lang = lang;
+  document.documentElement.dir = lang === "en" ? "ltr" : "rtl";
+  applyTranslations(lang);
+}
+
 document.getElementById("langSwitcher").addEventListener("change", function () {
-  const lang = this.value;
-  if (lang === "en") {
-    document.documentElement.lang = "en";
-    document.documentElement.dir = "ltr";
-    alert("שפה באנגלית עדיין לא זמינה – coming soon");
-  } else {
-    document.documentElement.lang = "he";
-    document.documentElement.dir = "rtl";
-  }
+  setLanguage(this.value);
 });
+
+// Initialize with current document language
+setLanguage(document.documentElement.lang || "he");

--- a/public/style.css
+++ b/public/style.css
@@ -1,6 +1,6 @@
 body {
   font-family: sans-serif;
-  direction: rtl;
+  direction: inherit;
   margin: 0;
   padding: 0;
   background-color: #f8f9fa;


### PR DESCRIPTION
## Summary
- add element IDs for translations
- make layout direction inherit from html element
- replace the alert with real English translations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846ecd7e7bc83258876c25cda1a623b