### PR TITLE
Improve UI with bilingual layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,47 +8,80 @@
 </head>
 <body>
   <header>
-    <div class="logo" id="logo">בינה לקהילה ומסורת</div>
-    <nav>
-      <select id="langSwitcher">
-        <option value="he" selected>עברית</option>
-        <option value="en">English</option>
-      </select>
-      <button>🔍</button>
-      <button id="btnLogin">התחברות</button>
-      <button id="btnSignup" class="primary">הרשמה</button>
+    <div class="top-bar">
+      <div class="top-left">
+        <select id="langSwitcher">
+          <option value="he" selected>עברית</option>
+          <option value="en">English</option>
+        </select>
+        <span id="selectedCommunityLabel">קהילה נבחרת:</span>
+        <select id="communitySelect">
+          <option>אהבת חסד</option>
+        </select>
+      </div>
+      <div class="user-menu">
+        <span id="userName">יוסי לוי</span>
+        <span>🧑</span>
+        <span>⚙️</span>
+      </div>
+    </div>
+    <nav class="main-menu">
+      <a href="#" id="navHome">בית</a>
+      <a href="#" id="navAliyot">עליות</a>
+      <a href="#" id="navMessages">הודעות</a>
+      <a href="#" id="navClasses">שיעורים</a>
+      <a href="#" id="navPayments">תשלומים</a>
+      <a href="#" id="navTorah">ספרי תורה</a>
     </nav>
   </header>
 
   <main>
-    <section class="search-box">
-      <h2 id="searchTitle">מחפשים בית כנסת קרוב?</h2>
-      <p id="searchDesc">הכנס את המיקום שלך או שם קהילה:</p>
-      <input id="searchInput" type="text" placeholder="הכנס את המיקום שלך או שם קהילה">
-      <button>🔍</button>
+    <section class="welcome">
+      <p id="welcomeMain">✔ ברוך הבא יוסי, אתה גבאי ב"אהבת חסד"</p>
+      <p id="welcomeSecondary">🕍 אתה גם חבר ב: "תפארת משה" (משתמש רגיל)</p>
+      <button id="btnSwitchCommunity">החלפת קהילה ⮕</button>
     </section>
 
-    <section class="apps">
-      <h3 id="appsTitle">רוצה להישאר מחובר?</h3>
-      <p id="appsDesc">הורד את האפליקציה שלנו לסלולרי:</p>
-      <button>Google Play</button>
-      <button>App Store</button>
-    </section>
-
-    <section class="features">
-      <h3 id="featuresTitle">מה אפשר לעשות עם המערכת?</h3>
-      <ul>
-        <li><span id="feature1">לקבל זמני תפילה ופעילויות בקהילה</span></li>
-        <li><span id="feature2">להירשם, לתרום, להודיע הודעות</span></li>
-        <li><span id="feature3">לנהל עליות, ספרי תורה, חברים בקהילה</span></li>
-      </ul>
-    </section>
-
-    <section class="cta">
-      <h3 id="ctaTitle">חדש כאן?</h3>
-      <button id="btnJoin">רוצה להצטרף לקהילה</button>
-      <button id="btnCreate" class="primary">מנהל קהילה – פתח קהילה</button>
-    </section>
+    <div class="grid">
+      <section class="box">
+        <h3 id="todayServicesTitle">שירותי היום</h3>
+        <p id="serviceShacharit">שחרית: 06:30</p>
+        <p id="serviceMincha">מנחה: 18:40</p>
+      </section>
+      <section class="box">
+        <h3 id="aliyotTitle">עליות לשבת</h3>
+        <p id="aliyotMaftir">מפטיר: לא הוקצה <button id="editAliyot">עריכה ⮕</button></p>
+        <p id="aliyotHaftara">הפטרה: כהן</p>
+      </section>
+      <section class="box">
+        <h3 id="messagesTitle">הודעות קהילה</h3>
+        <ul>
+          <li id="msg1">פגישת ועד ביום שלישי</li>
+          <li id="msg2">ערב שירה בחמישי</li>
+        </ul>
+      </section>
+      <section class="box">
+        <h3 id="classesTitle">השיעורים השבוע</h3>
+        <ul>
+          <li id="class1">הלכה יומית ב-19:00</li>
+          <li id="class2">דף יומי ב-20:15</li>
+        </ul>
+      </section>
+      <section class="box">
+        <h3 id="paymentTitle">סטטוס תשלומים</h3>
+        <ul>
+          <li id="paymentDebt">חוב: דמי חבר שנתיים</li>
+          <li id="paymentLast">תשלום אחרון: ניסן</li>
+        </ul>
+      </section>
+      <section class="box">
+        <h3 id="torahTitle">ספרי תורה</h3>
+        <ul>
+          <li id="torah1">תורה כהן: בבית הכנסת</li>
+          <li id="torah2">תורה לוי: הושאל לחולון</li>
+        </ul>
+      </section>
+    </div>
   </main>
   <script src="scripts.js"></script>
 </body>

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -1,61 +1,103 @@
 const translations = {
   en: {
     title: "Kolekta - Wisdom for Community and Tradition",
-    logo: "Wisdom for Community & Tradition",
-    login: "Login",
-    signup: "Sign Up",
-    searchTitle: "Looking for a nearby synagogue?",
-    searchDesc: "Enter your location or community name:",
-    searchPlaceholder: "Enter your location or community name",
-    appsTitle: "Want to stay connected?",
-    appsDesc: "Download our mobile app:",
-    featuresTitle: "What can you do with the system?",
-    feature1: "Get prayer times and community activities",
-    feature2: "Register, donate, send announcements",
-    feature3: "Manage aliyot, Torah scrolls, community members",
-    ctaTitle: "New here?",
-    join: "Want to join a community",
-    create: "Community admin – open a community",
+    selectedCommunityLabel: "Selected community:",
+    navHome: "Home",
+    navAliyot: "Aliyot",
+    navMessages: "Messages",
+    navClasses: "Classes",
+    navPayments: "Payments",
+    navTorah: "Sifrei Torah",
+    welcomeMain: "\u2714 Welcome Yossi, you are a Gabai in \"Ahavat Hesed\"",
+    welcomeSecondary: "\uD83D\uDED0 You are also a member of: \"Tiferet Moshe\" (regular user)",
+    btnSwitchCommunity: "Switch community \u27A5",
+    todayServicesTitle: "Today's Services",
+    serviceShacharit: "Shacharit: 06:30",
+    serviceMincha: "Mincha: 18:40",
+    aliyotTitle: "Aliyot for Shabbat",
+    aliyotMaftir: "Maftir: Not assigned",
+    editAliyot: "Edit \u27A5",
+    aliyotHaftara: "Haftarah: Cohen",
+    messagesTitle: "Community Messages",
+    msg1: "Board meeting Tuesday",
+    msg2: "Singing night Thursday",
+    classesTitle: "This Week's Classes",
+    class1: "Daily Halacha at 19:00",
+    class2: "Daf Yomi at 20:15",
+    paymentTitle: "Payment Status",
+    paymentDebt: "Debt: annual membership",
+    paymentLast: "Last payment: Nissan",
+    torahTitle: "Sifrei Torah",
+    torah1: "Torah Cohen: in the synagogue",
+    torah2: "Torah Levi: loaned to Holon"
   },
   he: {
     title: "קולקטה - בינה לקהילה ומסורת",
-    logo: "בינה לקהילה ומסורת",
-    login: "התחברות",
-    signup: "הרשמה",
-    searchTitle: "מחפשים בית כנסת קרוב?",
-    searchDesc: "הכנס את המיקום שלך או שם קהילה:",
-    searchPlaceholder: "הכנס את המיקום שלך או שם קהילה",
-    appsTitle: "רוצה להישאר מחובר?",
-    appsDesc: "הורד את האפליקציה שלנו לסלולרי:",
-    featuresTitle: "מה אפשר לעשות עם המערכת?",
-    feature1: "לקבל זמני תפילה ופעילויות בקהילה",
-    feature2: "להירשם, לתרום, להודיע הודעות",
-    feature3: "לנהל עליות, ספרי תורה, חברים בקהילה",
-    ctaTitle: "חדש כאן?",
-    join: "רוצה להצטרף לקהילה",
-    create: "מנהל קהילה – פתח קהילה",
-  },
+    selectedCommunityLabel: "קהילה נבחרת:",
+    navHome: "בית",
+    navAliyot: "עליות",
+    navMessages: "הודעות",
+    navClasses: "שיעורים",
+    navPayments: "תשלומים",
+    navTorah: "ספרי תורה",
+    welcomeMain: "✔ ברוך הבא יוסי, אתה גבאי ב\"אהבת חסד\"",
+    welcomeSecondary: "🕍 אתה גם חבר ב: \"תפארת משה\" (משתמש רגיל)",
+    btnSwitchCommunity: "החלפת קהילה ⮕",
+    todayServicesTitle: "שירותי היום",
+    serviceShacharit: "שחרית: 06:30",
+    serviceMincha: "מנחה: 18:40",
+    aliyotTitle: "עליות לשבת",
+    aliyotMaftir: "מפטיר: לא הוקצה",
+    editAliyot: "עריכה ⮕",
+    aliyotHaftara: "הפטרה: כהן",
+    messagesTitle: "הודעות קהילה",
+    msg1: "פגישת ועד ביום שלישי",
+    msg2: "ערב שירה בחמישי",
+    classesTitle: "השיעורים השבוע",
+    class1: "הלכה יומית ב-19:00",
+    class2: "דף יומי ב-20:15",
+    paymentTitle: "סטטוס תשלומים",
+    paymentDebt: "חוב: דמי חבר שנתיים",
+    paymentLast: "תשלום אחרון: ניסן",
+    torahTitle: "ספרי תורה",
+    torah1: "תורה כהן: בבית הכנסת",
+    torah2: "תורה לוי: הושאל לחולון"
+  }
 };
 
 function applyTranslations(lang) {
   const t = translations[lang];
   if (!t) return;
   document.title = t.title;
-  document.getElementById("logo").innerText = t.logo;
-  document.getElementById("btnLogin").innerText = t.login;
-  document.getElementById("btnSignup").innerText = t.signup;
-  document.getElementById("searchTitle").innerText = t.searchTitle;
-  document.getElementById("searchDesc").innerText = t.searchDesc;
-  document.getElementById("searchInput").placeholder = t.searchPlaceholder;
-  document.getElementById("appsTitle").innerText = t.appsTitle;
-  document.getElementById("appsDesc").innerText = t.appsDesc;
-  document.getElementById("featuresTitle").innerText = t.featuresTitle;
-  document.getElementById("feature1").innerText = t.feature1;
-  document.getElementById("feature2").innerText = t.feature2;
-  document.getElementById("feature3").innerText = t.feature3;
-  document.getElementById("ctaTitle").innerText = t.ctaTitle;
-  document.getElementById("btnJoin").innerText = t.join;
-  document.getElementById("btnCreate").innerText = t.create;
+  document.getElementById("selectedCommunityLabel").innerText = t.selectedCommunityLabel;
+  document.getElementById("navHome").innerText = t.navHome;
+  document.getElementById("navAliyot").innerText = t.navAliyot;
+  document.getElementById("navMessages").innerText = t.navMessages;
+  document.getElementById("navClasses").innerText = t.navClasses;
+  document.getElementById("navPayments").innerText = t.navPayments;
+  document.getElementById("navTorah").innerText = t.navTorah;
+  document.getElementById("welcomeMain").innerText = t.welcomeMain;
+  document.getElementById("welcomeSecondary").innerText = t.welcomeSecondary;
+  document.getElementById("btnSwitchCommunity").innerText = t.btnSwitchCommunity;
+  document.getElementById("todayServicesTitle").innerText = t.todayServicesTitle;
+  document.getElementById("serviceShacharit").innerText = t.serviceShacharit;
+  document.getElementById("serviceMincha").innerText = t.serviceMincha;
+  document.getElementById("aliyotTitle").innerText = t.aliyotTitle;
+  document.getElementById("aliyotMaftir").childNodes[0].nodeValue = t.aliyotMaftir + " ";
+  document.getElementById("editAliyot").innerText = t.editAliyot;
+  document.getElementById("aliyotHaftara").innerText = t.aliyotHaftara;
+  document.getElementById("messagesTitle").innerText = t.messagesTitle;
+  document.getElementById("msg1").innerText = t.msg1;
+  document.getElementById("msg2").innerText = t.msg2;
+  document.getElementById("classesTitle").innerText = t.classesTitle;
+  document.getElementById("class1").innerText = t.class1;
+  document.getElementById("class2").innerText = t.class2;
+  document.getElementById("paymentTitle").innerText = t.paymentTitle;
+  document.getElementById("paymentDebt").innerText = t.paymentDebt;
+  document.getElementById("paymentLast").innerText = t.paymentLast;
+  document.getElementById("torahTitle").innerText = t.torahTitle;
+  document.getElementById("torah1").innerText = t.torah1;
+  document.getElementById("torah2").innerText = t.torah2;
 }
 
 function setLanguage(lang) {

--- a/public/style.css
+++ b/public/style.css
@@ -48,3 +48,60 @@ input {
   border: 1px solid #ccc;
   border-radius: 4px;
 }
+/* Additional layout styles */
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5em 1em;
+  background: #ffffff;
+}
+
+.top-left,
+.user-menu {
+  display: flex;
+  align-items: center;
+}
+
+.top-left select,
+.user-menu span {
+  margin: 0 0.5em;
+}
+
+.main-menu {
+  display: flex;
+  justify-content: center;
+  background: #2a61c3;
+  color: #fff;
+  padding: 0.5em;
+}
+
+.main-menu a {
+  color: #fff;
+  text-decoration: none;
+  margin: 0 0.5em;
+}
+
+.welcome {
+  background: #e9ecef;
+  text-align: center;
+  padding: 1em;
+  border-radius: 8px;
+  margin: 1em auto;
+  max-width: 800px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1em;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.grid .box {
+  background: white;
+  padding: 1em;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+}


### PR DESCRIPTION
## Summary
- redesign the homepage around a grid layout
- style the new sections with a top bar and grid boxes
- translate all text for English/Hebrew switching

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846f349185c832587a0d23edad2c0fe